### PR TITLE
Upgrade Jetpack Compose version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,7 @@ android {
 
     composeOptions {
         kotlinCompilerVersion "1.4.0"
-        kotlinCompilerExtensionVersion "1.0.0-alpha03"
+        kotlinCompilerExtensionVersion "1.0.0-alpha05"
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
@@ -82,9 +82,9 @@ dependencies {
     implementation "com.google.android.material:material:1.2.1"
 
     // Jetpack Compose
-    implementation "androidx.compose.animation:animation:1.0.0-alpha03"
-    implementation "androidx.compose.ui:ui:1.0.0-alpha03"
-    implementation "androidx.compose.material:material:1.0.0-alpha03"
+    implementation "androidx.compose.animation:animation:1.0.0-alpha05"
+    implementation "androidx.compose.ui:ui:1.0.0-alpha05"
+    implementation "androidx.compose.material:material:1.0.0-alpha05"
 
-    implementation "androidx.ui:ui-tooling:1.0.0-alpha03"
+    implementation "androidx.ui:ui-tooling:1.0.0-alpha05"
 }

--- a/app/src/main/java/ch/heigvd/ihm/stickies/details/CircularPill.kt
+++ b/app/src/main/java/ch/heigvd/ihm/stickies/details/CircularPill.kt
@@ -10,7 +10,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Providers
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,10 +20,12 @@ import androidx.ui.tooling.preview.Preview
 fun CircularPill(
     color: Color,
     modifier: Modifier = Modifier,
+    filled: Boolean = false,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val border = remember(color) { color.copy(alpha = 0.1f) }
-    val background = remember(color) { color.copy(alpha = 0.05f) }
+    val backgroundAlpha = if (filled) 0.15f else 0.05f
+    val border = color.copy(alpha = 0.1f)
+    val background = color.copy(alpha = backgroundAlpha)
     Column(
         modifier
             .preferredSize(76.dp)
@@ -42,9 +43,14 @@ fun CircularPill(
 @Composable
 @Preview
 private fun CircularPillPreview() {
-    Stack(Modifier.background(Color.White).padding(16.dp)) {
+    Column(Modifier.background(Color.White).padding(16.dp)) {
         CircularPill(color = Color.Red) {
             Text("Tue", style = MaterialTheme.typography.subtitle1)
+            Text("•", style = MaterialTheme.typography.subtitle2)
+        }
+
+        CircularPill(color = Color.Red, Modifier.padding(top = 16.dp), filled = true) {
+            Text("Wed", style = MaterialTheme.typography.subtitle1)
             Text("•", style = MaterialTheme.typography.subtitle2)
         }
     }

--- a/app/src/main/java/ch/heigvd/ihm/stickies/details/CircularPill.kt
+++ b/app/src/main/java/ch/heigvd/ihm/stickies/details/CircularPill.kt
@@ -1,10 +1,7 @@
 package ch.heigvd.ihm.stickies.details
 
 import androidx.compose.animation.animate
-import androidx.compose.foundation.ContentColorAmbient
-import androidx.compose.foundation.Text
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.MaterialTheme
@@ -35,7 +32,7 @@ fun CircularPill(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Providers(ContentColorAmbient provides contentColorFor(color)) {
+        Providers(AmbientContentColor provides contentColorFor(color)) {
             content()
         }
     }

--- a/app/src/main/java/ch/heigvd/ihm/stickies/details/CircularPill.kt
+++ b/app/src/main/java/ch/heigvd/ihm/stickies/details/CircularPill.kt
@@ -1,0 +1,51 @@
+package ch.heigvd.ihm.stickies.details
+
+import androidx.compose.foundation.ContentColorAmbient
+import androidx.compose.foundation.Text
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Providers
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.ui.tooling.preview.Preview
+
+@Composable
+fun CircularPill(
+    color: Color,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val border = remember(color) { color.copy(alpha = 0.1f) }
+    val background = remember(color) { color.copy(alpha = 0.05f) }
+    Column(
+        modifier
+            .preferredSize(76.dp)
+            .background(background, CircleShape)
+            .border(4.dp, border, CircleShape),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Providers(ContentColorAmbient provides contentColorFor(color)) {
+            content()
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun CircularPillPreview() {
+    Stack(Modifier.background(Color.White).padding(16.dp)) {
+        CircularPill(color = Color.Red) {
+            Text("Tue", style = MaterialTheme.typography.subtitle1)
+            Text("•", style = MaterialTheme.typography.subtitle2)
+        }
+    }
+}

--- a/app/src/main/java/ch/heigvd/ihm/stickies/details/CircularPill.kt
+++ b/app/src/main/java/ch/heigvd/ihm/stickies/details/CircularPill.kt
@@ -1,5 +1,6 @@
 package ch.heigvd.ihm.stickies.details
 
+import androidx.compose.animation.animate
 import androidx.compose.foundation.ContentColorAmbient
 import androidx.compose.foundation.Text
 import androidx.compose.foundation.background
@@ -23,8 +24,8 @@ fun CircularPill(
     filled: Boolean = false,
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val backgroundAlpha = if (filled) 0.15f else 0.05f
-    val border = color.copy(alpha = 0.1f)
+    val backgroundAlpha = animate(if (filled) 1f else 0.1f)
+    val border = animate(color)
     val background = color.copy(alpha = backgroundAlpha)
     Column(
         modifier
@@ -46,11 +47,6 @@ private fun CircularPillPreview() {
     Column(Modifier.background(Color.White).padding(16.dp)) {
         CircularPill(color = Color.Red) {
             Text("Tue", style = MaterialTheme.typography.subtitle1)
-            Text("•", style = MaterialTheme.typography.subtitle2)
-        }
-
-        CircularPill(color = Color.Red, Modifier.padding(top = 16.dp), filled = true) {
-            Text("Wed", style = MaterialTheme.typography.subtitle1)
             Text("•", style = MaterialTheme.typography.subtitle2)
         }
     }

--- a/app/src/main/java/ch/heigvd/ihm/stickies/details/ColorPicker.kt
+++ b/app/src/main/java/ch/heigvd/ihm/stickies/details/ColorPicker.kt
@@ -1,0 +1,62 @@
+package ch.heigvd.ihm.stickies.details
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.ui.tooling.preview.Preview
+
+enum class SelectionColor {
+    Blue,
+    Pink,
+    Yellow,
+    Orange,
+}
+
+@Composable
+fun ColorPicker(
+    selected: SelectionColor,
+    onClick: (SelectionColor) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(modifier) {
+        CircularPill(
+            color = Color(0xFFD4F1EA),
+            Modifier.clickable(onClick = { onClick(SelectionColor.Blue) }, indication = null),
+            filled = selected == SelectionColor.Blue,
+            content = {})
+        Spacer(Modifier.width(16.dp))
+        CircularPill(
+            color = Color(0xFFFFDDF8),
+            Modifier.clickable(onClick = { onClick(SelectionColor.Pink) }, indication = null),
+            filled = selected == SelectionColor.Pink,
+            content = {})
+        Spacer(Modifier.width(16.dp))
+        CircularPill(
+            color = Color(0xFFFFFFD1),
+            Modifier.clickable(onClick = { onClick(SelectionColor.Yellow) }, indication = null),
+            filled = selected == SelectionColor.Yellow,
+            content = {})
+        Spacer(Modifier.width(16.dp))
+        CircularPill(
+            color = Color(0xFFFFE2D1),
+            Modifier.clickable(onClick = { onClick(SelectionColor.Orange) }, indication = null),
+            filled = selected == SelectionColor.Orange,
+            content = {})
+    }
+}
+
+@Composable
+@Preview
+private fun ColorPickerPreview() {
+    Stack(Modifier.background(Color.White).padding(16.dp)) {
+        val (color, setColor) = remember { mutableStateOf(SelectionColor.Pink) }
+        ColorPicker(selected = color, onClick = setColor, Modifier.align(Alignment.Center))
+    }
+}

--- a/app/src/main/java/ch/heigvd/ihm/stickies/stickies/Sticky.kt
+++ b/app/src/main/java/ch/heigvd/ihm/stickies/stickies/Sticky.kt
@@ -2,7 +2,7 @@ package ch.heigvd.ihm.stickies.stickies
 
 import androidx.compose.foundation.Text
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Stack
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.preferredSize
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -33,7 +33,7 @@ fun Sticky(
         shape = RoundedCornerShape(8.dp),
         elevation = 4.dp,
     ) {
-        Stack(alignment = Alignment.Center) {
+        Box(alignment = Alignment.Center) {
             content()
             val (checked, setChecked) = remember { mutableStateOf(false) }
             Switch(checked = checked, onCheckedChange = { setChecked(!checked) })
@@ -44,7 +44,7 @@ fun Sticky(
 @Composable
 @Preview
 fun Demo() {
-    Stack(Modifier.fillMaxSize(), alignment = Alignment.Center) {
+    Box(Modifier.fillMaxSize(), alignment = Alignment.Center) {
         val (value, setValue) = remember { mutableStateOf(Color.Red) }
         Sticky(
             color = value,

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.0-alpha12"
+        classpath "com.android.tools.build:gradle:4.2.0-alpha13"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10"
         classpath "org.jetbrains.kotlinx:atomicfu-gradle-plugin:0.14.3"
     }


### PR DESCRIPTION
The alpha05 release of Jetpack Compose is available, and fixes some issues with list scrolling and snapshot state management.

This requires the usage of the latest Canary Release of Android Studio.